### PR TITLE
Create multiple issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,6 @@ about: Create a report to help us improve
 title: "[BUG]"
 labels: bug
 assignees: realodix
-
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: bug
+assignees: realodix
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. [First Step]
+2. [Second Step]
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Actual behavoir**
+What actually happens.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional Information**
+Any additional information, configuration or data that might be necessary to reproduce the issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[REQUEST]"
+labels: new feature
+assignees: realodix
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional Information**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
When you add a manually-created issue template to your repository, project contributors will automatically see the template's contents in the issue body.

- [x] Add bug report #206
- [x] Add feature request #207 