### PR TITLE
The setUp methods require a void return type

### DIFF
--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -8,7 +8,7 @@ use Tests\TestCase;
 
 class UserTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
The `setUp` and `tearDown` methods now require a void return type

```
protected function setUp(): void
protected function tearDown(): void
```